### PR TITLE
added css for the splitpane_divider class

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,9 @@ exports.decorateConfig = config => {
             ::selection {
                 background: #9198A2 !important;
             }
+            .splitpane_divider {
+              background-color: rgba(205, 210, 233, 0.5) !important;
+            }
         `
     });
 };


### PR DESCRIPTION
The color used is the same as the foregroundColor, but with an alpha
value of .5 applied. This makes the border somewhat subtile.

Fixes: #8 